### PR TITLE
fix project name so doesn't conflict with jsweet-examples

### DIFF
--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>jsweet-examples</name>
+	<name>jsweet-quickstart</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
The project name in .project was `jsweet-examples` which conflicted when I tried to import into eclipse because I already had `jsweet-examples` imported. I've renamed it to `jsweet-quickstart`.