### PR TITLE
Added <bundle>true</bundle> to pom.xml which avoids circular dependen…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
 					<targetVersion>ES6</targetVersion>
 					<module>none</module>
 					<moduleResolution>classic</moduleResolution>
+                                        <bundle>true</bundle>
 				</configuration>
 				<executions>
 					<execution>

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -13,7 +13,7 @@
 
 	<!-- The transpiled output of the QuickStart.java source file (mvn generate-sources) -->
 	<script type="text/javascript"
-		src="../target/js/quickstart/QuickStart.js"></script>
+		src="../target/js/bundle.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Just a minor edit where I added 'bundle:true' to the pom.xml file and made a corresponding edit to the index.html file which avoids circular dependency errors: "TypeError: Super expression must either be null or a function, not undefined". The fix to this problem is to bundle files as mentioned here: 
https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de
Of course in this simple Quickstart example where there are so few javascript files and no circular dependency problems, it's unnecessary. But if new users use this quickstart as a working template to convert their own project from Java to Javascript, it's best that we include the best default options to make their experience as painless as possible. When I ran into this circular dependency problem I was close to giving up on JSweet since I had no idea why it didn't work. I happened upon this fix and persevered and am now very happy with JSweet. So I would like to contribute this minor edit. Thank you for the great work on JSweet!
PS: This is my first pull request on Github ever. Apologies if I made an error. I tested it and it ran fine so hopefully it's all good.